### PR TITLE
Support for running `setup.py nosetests`

### DIFF
--- a/nosepipe.py
+++ b/nosepipe.py
@@ -15,7 +15,7 @@ import sys
 
 import nose.plugins
 
-__version__ = "0.5"
+__version__ = "0.5-post1"
 
 SUBPROCESS_ENV_KEY = "NOSE_WITH_PROCESS_ISOLATION_REPORTER"
 

--- a/nosepipe.py
+++ b/nosepipe.py
@@ -154,7 +154,7 @@ class SubprocessTestProxy(object):
                                      stderr=subprocess.STDOUT,
                                      shell=useshell,
                                      )
-        except OSError, e:
+        except OSError as e:
             raise Exception("Error running %s [%s]" % (argv[0], e))
 
         try:
@@ -203,7 +203,7 @@ class ProcessIsolationPlugin(nose.plugins.Plugin):
         # When not running directly as nosetests, we need to run the
         # sub-processes as `nosetests`, not `setup.py nosetests` as the output
         # of setup.py interferes with the nose output.  So, we need to find
-        # where nosetests # is on the command-line and then run the
+        # where nosetests is on the command-line and then run the
         # sub-processes command-line using the args from that location.
 
         nosetests_index = None

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     license = "BSD",
     platforms = ["any"],
 
-    install_requires = ["nose>=0.1.0, ==dev"],
+    install_requires = ["nose>=0.1.0"],
 
     url = "http://github.com/dmccombs/nosepipe/",
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     license = "BSD",
     platforms = ["any"],
 
-    install_requires = ["nose>=0.1.0"],
+    install_requires = ["nose>=0.1.0, ==dev"],
 
     url = "http://github.com/dmccombs/nosepipe/",
 


### PR DESCRIPTION
The nosetest plugin wasn't working when running under `setup.py`.  It would fail because the subprocesses would be run as setup.py processes instead of nosetests processes.  The output from setup.py was confusing nosetests.  So, when running under `setup.py`, nosetests needs to make sure the sub-process command is `nosetests...` instead of `setup.py nosetests...`

I also had dependency problems with nose==dev in setup.py.  Getting the following error:

```
python setup.py develop
...
No local packages or download links found for nose==dev,>=0.1.0
error: Could not find suitable distribution for Requirement.parse('nose==dev,>=0.1.0')
``` 