### PR TITLE
Support for running under setup.py/manage.py and travis setup.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 build/
 dist/
 *.egg-info/
+wheelhouse/
+.eggs/
+*.egg/
+*.pyc
+*.sw?
+.coverage
+test-support/django/db.sqlite3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "pypy"
+env:
+  - EGGS="nose==dev"
+  - EGGS=""
+# command to install dependencies, e.g. pip install -r requirements.txt
+install:
+  - if [ -n "$EGGS" ] ; then pip install $EGGS --allow-external=nose --allow-unverified=nose ; fi
+  - python setup.py develop
+# command to run tests, e.g. python setup.py test
+script:
+  - # python setup.py nosetests --verbosity=3
+  - nosetests --verbosity=3

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,10 @@ env:
   - EGGS=""
 # command to install dependencies, e.g. pip install -r requirements.txt
 install:
-  - if [ -n "$EGGS" ] ; then pip install $EGGS --allow-external=nose --allow-unverified=nose ; fi
+  - pip='travis_retry pip'
+  - if [[ $TRAVIS_PYTHON_VERSION =~ '2.6' ]] ; then $pip install 'Django<1.7' ; fi
+  - if [[ -n "$EGGS" ]] ; then $pip install $EGGS --allow-external=nose --allow-unverified=nose ; fi
   - python setup.py develop
 # command to run tests, e.g. python setup.py test
 script:
-  - # python setup.py nosetests --verbosity=3
-  - nosetests --verbosity=3
+  - python setup.py nosetests --verbosity=3

--- a/nosepipe.py
+++ b/nosepipe.py
@@ -255,18 +255,20 @@ class ProcessIsolationPlugin(nose.plugins.Plugin):
     def configure(self, options, config):
         self.individual = options.with_process_isolation_individual
         nose.plugins.Plugin.configure(self, options, config)
-        if self.enabled and options.enable_plugin_coverage:
-            from coverage import coverage
+        try:
+            if self.enabled and options.enable_plugin_coverage:
+                from coverage import coverage
 
-            def nothing(*args, **kwargs):
-                pass
+                def nothing(*args, **kwargs):
+                    pass
 
-            # Monkey patch coverage to fix the reporting and friends
-            coverage.start = nothing
-            coverage.stop = nothing
-            coverage.combine = nothing
-            coverage.save = coverage.load
-
+                # Monkey patch coverage to fix the reporting and friends
+                coverage.start = nothing
+                coverage.stop = nothing
+                coverage.combine = nothing
+                coverage.save = coverage.load
+        except:
+            pass
 
     def do_isolate(self, test):
         # XXX is there better way to access 'nosepipe_isolate'?

--- a/nosepipe.py
+++ b/nosepipe.py
@@ -147,12 +147,16 @@ class SubprocessTestProxy(object):
             useshell = True
 
         self.logger.debug("Executing %s", " ".join(argv))
-        popen = subprocess.Popen(argv,
-                                 cwd=self._cwd,
-                                 stdout=subprocess.PIPE,
-                                 stderr=subprocess.STDOUT,
-                                 shell=useshell,
-                                 )
+        try:
+            popen = subprocess.Popen(argv,
+                                     cwd=self._cwd,
+                                     stdout=subprocess.PIPE,
+                                     stderr=subprocess.STDOUT,
+                                     shell=useshell,
+                                     )
+        except OSError as e:
+            raise Exception("Error running %s [%s]" % (argv[0], e))
+
         try:
             stdout = popen.stdout
             while True:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     license = "BSD",
     platforms = ["any"],
 
-    install_requires = ["nose>=0.1.0, ==dev"],
+    install_requires = ["nose>=0.1.0"],
 
     url = "http://github.com/dmccombs/nosepipe/",
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ setup(
 
     install_requires = ["nose>=0.1.0"],
 
+    tests_require = ["django-nose"],
+
     url = "http://github.com/dmccombs/nosepipe/",
 
     long_description = """\

--- a/test-support/django/manage.py
+++ b/test-support/django/manage.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+import os
+import sys
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "sample.settings")
+
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)

--- a/test-support/django/sample/settings.py
+++ b/test-support/django/sample/settings.py
@@ -1,0 +1,52 @@
+"""
+Django settings for nosepipe project.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/1.7/topics/settings/
+
+For the full list of settings and their values, see
+https://docs.djangoproject.com/en/1.7/ref/settings/
+"""
+
+# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+import os
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+
+# Quick-start development settings - unsuitable for production
+# See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = 'sa5ia(bu*m1j@hkiap#1yx3#vp0-(_ige!da_zk6=3*knhp1p7'
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = True
+
+TEMPLATE_DEBUG = True
+
+ALLOWED_HOSTS = []
+
+# Application definition
+
+INSTALLED_APPS = (
+    'django_nose',
+)
+
+MIDDLEWARE_CLASSES = ()
+
+# Database
+# https://docs.djangoproject.com/en/1.7/ref/settings/#databases
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+    }
+}
+
+# Use django_nose to run tests
+
+TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+
+# Enable nosepipe
+
+NOSE_ARGS = ['--verbose', '--with-process-isolation']

--- a/test-support/django/sample/tests.py
+++ b/test-support/django/sample/tests.py
@@ -1,0 +1,6 @@
+from django.test import TestCase
+
+
+class BaseTestCase(TestCase):
+    def test_simple(self):
+        self.assertTrue(1)

--- a/test_nosepipe.rst
+++ b/test_nosepipe.rst
@@ -110,4 +110,4 @@ Multiple failing tests:
     ----------------------------------------------------------------------
     Ran 2 tests in ...s
     <BLANKLINE>
-    FAILED (failures=1, errors=1)
+    FAILED (errors=1, failures=1)

--- a/test_nosepipe.rst
+++ b/test_nosepipe.rst
@@ -89,7 +89,7 @@ Multiple failing tests:
     ...     argv=["nosetests", "-v", "--with-process-isolation",
     ...           os.path.join(directory_with_tests, "failing")],
     ...     plugins=plugins)
-    ...     # doctest: +REPORT_NDIFF
+    ...     # doctest: +REPORT_NDIFF +ELLIPSIS
     failing_tests.erroring_test ... ERROR
     failing_tests.failing_test ... FAIL
     <BLANKLINE>
@@ -111,3 +111,57 @@ Multiple failing tests:
     Ran 2 tests in ...s
     <BLANKLINE>
     FAILED (errors=1, failures=1)
+
+Django nose:
+
+   >>> import subprocess
+   >>> import re
+
+   >>> # run a command and return it's output or error output
+   >>> def run_cmd(argv):
+   ...     try:  # python 2.7+
+   ...         output = subprocess.check_output(argv, stderr=subprocess.STDOUT).decode('ascii')
+   ...     except subprocess.CalledProcessError as e:
+   ...         output = "Error running:\n{0}\nOutput:\n{1}".format(argv, e.output)
+   ...     except Exception as subprocess_e:
+   ...         try:
+   ...             useshell = False
+   ...             if sys.platform == 'win32':
+   ...                 useshell = True
+   ...             popen = subprocess.Popen(argv,
+   ...                   shell=useshell,
+   ...                   stdout=subprocess.PIPE,
+   ...                   stderr=subprocess.PIPE,
+   ...             )
+   ...             stdout, stderr = popen.communicate()
+   ...             output = "{0}{1}".format(stderr, stdout)
+   ...         except OSError as popen_e:
+   ...             output = "Error running:\n{0}\nSubprocess Output:\n{1}\nPopen Output".format(
+   ...                 argv, subprocess_e, popen_e)
+   ...     return output
+
+   >>> # find all .egg directories to add to the path (were installed by setup.py develop/test)
+   >>> top_dir = os.getcwd()
+   >>> eggs = []
+   >>> iseggdir = re.compile('\.egg$')
+   >>> for top, dirs, f in os.walk(top_dir):
+   ...     for dir in dirs:
+   ...         if iseggdir.search(dir):
+   ...             eggs += [os.path.join(top, dir)]
+
+   >>> django_dir = os.path.join(directory_with_tests, "django")
+   >>> os.chdir(django_dir)
+   >>> print(run_cmd(["env", 
+   ...     "PYTHONPATH={0}".format(":".join(eggs)), 
+   ...     "python", "manage.py", "test", "--verbosity=1"]))
+   ...     # doctest: +REPORT_NDIFF +ELLIPSIS
+   .
+   ----------------------------------------------------------------------
+   Ran 1 test in ...s
+   <BLANKLINE>
+   OK
+   nosetests --verbose --with-process-isolation --verbosity=1
+   Creating test database for alias 'default'...
+   Destroying test database for alias 'default'...
+   <BLANKLINE>
+   >>> os.chdir(top_dir)


### PR DESCRIPTION
I'm closing out https://github.com/dmccombs/nosepipe/pull/7 and moving the commits to this PR.  I basically rearranged the commits to make more sense.  The only additional changes on this PR are fully working tests for running under django_nose and as `setup.py nosetests`.

The nosepipe plugin wasn't working when running under setup.py or manage.py (django with django_nose). It would fail because the subprocesses would be run as setup.py/manage.py instead of nosetests processes. The output from the sub-process was confusing nosetests. So, when running under something other than nosetests, nosetests needs to make sure the sub-process command is nosetests... instead of setup.py nosetests...

I also had dependency problems with nose==dev in setup.py. Getting the following error:

```
python setup.py develop
...
No local packages or download links found for nose==dev,>=0.1.0
error: Could not find suitable distribution for Requirement.parse('nose==dev,>=0.1.0')
```

This seems to be due to the dependency being ==dev AND >=0.1.0 which doesn't seem to be able to be true.  I removed the ==dev but added a travis test case to specifically use the dev version of nose.

Finally, I added a .travis.yml which will make it simple to add automated CI jobs using http://travis-ci.org if you 'd like.  See the tests running from my fork here:

https://travis-ci.org/mdprewitt/nosepipe