### PR TITLE
Force binary mode on stdout in Windows.

### DIFF
--- a/nosepipe.py
+++ b/nosepipe.py
@@ -74,6 +74,11 @@ class ProcessIsolationReporterPlugin(nose.plugins.Plugin):
     def setOutputStream(self, stream):
         # we use stdout for IPC, so block all other output
         self._stream = sys.__stdout__
+        # prevent 0x0A (LF) byte automatically converting to 0x0D0A (CRLF)
+        # bytes by forcing stdout to binary mode on Windows
+        if sys.platform == 'win32':
+            import msvcrt
+            msvcrt.setmode(self._stream.fileno(), os.O_BINARY)
         return NullWritelnFile()
 
     def startTest(self, test):


### PR DESCRIPTION
As requested in issue #10 here's the change to fix IPC communication errors between the isolated sub-process and parent-process.

The issue was that on Windows when you write to STDOUT any LF-bytes gets automatically converted to CRLF-bytes. The conversion corrupts the binary based IPC communication.

This change fixes the corruption by changing STDOUT's mode from text mode to binary mode. 

I've tested this with Windows 7 x64 and Python 2.7.10.