### PR TITLE
Suppress functions under test from writing to stdout

### DIFF
--- a/nosepipe.py
+++ b/nosepipe.py
@@ -156,7 +156,7 @@ class SubprocessTestProxy(object):
             popen = subprocess.Popen(argv,
                                      cwd=self._cwd,
                                      stdout=subprocess.PIPE,
-                                     stderr=subprocess.STDOUT,
+                                     stderr=subprocess.PIPE,
                                      shell=useshell,
                                      )
         except OSError as e:


### PR DESCRIPTION
To fix the issue where errors/warning messages written to stdout by functions under test are overwriting IPC event messages, resulting in unexpected behaviour (Exception: short message body....
Something went wrong).



